### PR TITLE
Update python_version for 3.13

### DIFF
--- a/bmcremedy.json
+++ b/bmcremedy.json
@@ -12,7 +12,7 @@
     "product_vendor": "BMC Software",
     "product_name": "BMC Remedy",
     "product_version_regex": ".*",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "fips_compliant": true,
     "min_phantom_version": "5.3.5",
     "logo": "logo_bmcremedy.svg",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions-3.13`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions-3.13)